### PR TITLE
Added support for Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,4 @@ xrandr = "0.2"
 core-graphics = "0.23"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows-sys = { version = "0.52.0", features = ["Win32_UI_WindowsAndMessaging"] }
+windows-sys = { version = "0.52", features = ["Win32_UI_WindowsAndMessaging"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license     = "BSD-3-Clause"
 readme      = "README.md"
 homepage    = "https://github.com/cacilhas/resolution"
 repository  = "https://github.com/cacilhas/resolution"
-keywords    = ["screen", "linux", "macos"]
+keywords    = ["screen", "linux", "macos", "windows"]
 description = "Retrieves current screen resolution"
 edition     = "2021"
 
@@ -19,3 +19,6 @@ xrandr = "0.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-graphics = "0.23"
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows-sys = { version = "0.52.0", features = ["Win32_UI_WindowsAndMessaging"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,9 @@ use xrandr::XHandle;
 #[cfg(target_os = "macos")]
 use core_graphics::display::CGDisplay;
 
+#[cfg(target_os = "windows")]
+use windows_sys::Win32::UI::WindowsAndMessaging::GetSystemMetrics;
+
 #[cfg(target_os = "linux")]
 pub fn current_resolution() -> Result<(i32, i32), ResolutionError> {
     let monitors = XHandle::open()
@@ -34,9 +37,18 @@ pub fn current_resolution() -> Result<(i32, i32), ResolutionError> {
     Ok((width as i32, height as i32))
 }
 
+/// [Windows] Returns the resolution of the main display using a call to the `GetSystemMetrics` function of the Win32 API through the `windows-sys` crate.
+/// For more information about the `GetSystemMetrics` function, see Microsoft's official documentation: https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getsystemmetrics
+#[cfg(target_os = "windows")]
+pub fn current_resolution() -> Result<(i32, i32), ResolutionError> {
+    let width = unsafe { GetSystemMetrics(0) };
+    let height = unsafe { GetSystemMetrics(1) };
+    Ok((width, height))
+}
+
 // Defaults to error
 
-#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
 pub fn current_resolution() -> Result<(i32, i32), ResolutionError> {
     Err(ResolutionError::NotImplemented)
 }


### PR DESCRIPTION
Added support for the Windows operating system through the `window-sys` crate.

Tested on a computer running Windows 11 Home (version 22H2) on an Intel i9-12900H CPU.

Note that the `windows-sys` crate is a very thin wrapper over the native Windows API, and as such its function calls are unsafe. If this functionality is mission-critical to an application, a more fault-tolerant solution should be created.